### PR TITLE
Sheets in cache not getting refreshed

### DIFF
--- a/src/pages/Popup/scripts/fetchSheet.js
+++ b/src/pages/Popup/scripts/fetchSheet.js
@@ -10,7 +10,7 @@ class Sheet {
     });
     if (data) {
       this.response = data.response
-      this.last_accessed = data.last_access
+      this.last_accessed = data.last_accessed
     }
     // if sheet is older than 4 hrs. then re fetch it
     const min = 240;


### PR DESCRIPTION
**ISSUE**
The Sheets stored in the cache were not getting refreshed due to if condition not getting evaluated to check the 4 hrs interval.

**Resolved**
This was because of a typo in the spelling of accessed to access while setting the variable fetched from storage data