### PR TITLE
Minor changes in upcoming alarms

### DIFF
--- a/src/pages/Popup/components/AlarmUp.jsx
+++ b/src/pages/Popup/components/AlarmUp.jsx
@@ -219,7 +219,7 @@ class Alarmview extends Component {
                       primary={
                         alarm.custom
                           ? `${this.trunc(alarm.data.Name, 22)}`
-                          : `${alarm.data.A} ${this.trunc(alarm.data.B, 16)}`
+                          : `${alarm.data.A} ${this.trunc(alarm.data.B, 13)}`
                       }
                       secondary={`${alarm.time}`}
                     />
@@ -294,7 +294,7 @@ class Alarmview extends Component {
               <div
                 style={{ padding: '1rem', textAlign: 'center', width: '100%' }}
               >
-                <Typography>No alarms Present</Typography>
+                <Typography>No alarms</Typography>
               </div>
             )}
           </AccordionDetails>
@@ -324,7 +324,7 @@ class Alarmview extends Component {
               <div
                 style={{ padding: '1rem', textAlign: 'center', width: '100%' }}
               >
-                <Typography>No alarms Present</Typography>
+                <Typography>No alarms</Typography>
               </div>
             )}
           </AccordionDetails>
@@ -354,7 +354,7 @@ class Alarmview extends Component {
               <div
                 style={{ padding: '1rem', textAlign: 'center', width: '100%' }}
               >
-                <Typography>No alarms Present</Typography>
+                <Typography>No alarms</Typography>
               </div>
             )}
           </AccordionDetails>


### PR DESCRIPTION
Changed the truncate value from 16 to 13 for the alarm name and changed `No alarms Present` to `No alarms` in upcoming tab when there are no alarms